### PR TITLE
don't use code-link (requires R during post-processing)

### DIFF
--- a/_freeze/biodiversity/execute-results/html.json
+++ b/_freeze/biodiversity/execute-results/html.json
@@ -13,6 +13,6 @@
       "data": []
     },
     "preserve": {},
-    "postProcess": true
+    "postProcess": false
   }
 }

--- a/_freeze/statistics/execute-results/html.json
+++ b/_freeze/statistics/execute-results/html.json
@@ -13,6 +13,6 @@
       "data": []
     },
     "preserve": {},
-    "postProcess": true
+    "postProcess": false
   }
 }

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -51,4 +51,3 @@ format:
     theme: cosmo
     css: styles.css
     toc: true
-    code-link: true


### PR DESCRIPTION
This fixes the issue w/ the freezer you saw. The problem is that `code-link` actually uses the downlit package (so requires R).

Not exactly sure what to do about this, as `_freeze` doesn't necessarily mean "I don't want R as a requirement". A few options to make this better:

1) Fail as we do now
2) Fail with a more clear error message ("Rendering frozen content requires R and downlit package")
3) Skip downlit with a warning

I'd be inclined to do (3) especially since "repairing" the downlit dependency requires hand-editing JSON.
